### PR TITLE
Fix string validation error in challenge submission modal

### DIFF
--- a/src/interactions/challenge/modal.js
+++ b/src/interactions/challenge/modal.js
@@ -106,11 +106,11 @@ exports.modal = async function ({current_challenge, interaction, db, member_id, 
         .setRequired(false)
     if (current_challenge.submissions?.[member_id]) {
         const this_submission = db.ch.times[current_challenge.submissions[member_id].id]
-        submissionTime.setValue(time_fix(this_submission.time))
-        submissionNotes.setValue(this_submission.notes)
-        submissionProof.setValue(this_submission.proof)
-        submissionRTA.setValue(this_submission.rta)
-        submissionPlatform.setValue(this_submission.platform)
+        submissionTime.setValue(time_fix(this_submission.time) || "")
+        submissionNotes.setValue(this_submission.notes || "")
+        submissionProof.setValue(this_submission.proof || "")
+        submissionRTA.setValue(this_submission.rta ? time_fix(this_submission.rta) : "")
+        submissionPlatform.setValue(this_submission.platform || "")
     }
     const ActionRow1 = new ActionRowBuilder().addComponents(submissionTime)
     const ActionRow2 = new ActionRowBuilder().addComponents(submissionNotes)


### PR DESCRIPTION
Guard setValue calls against non-string values when pre-filling an
existing submission. When a stored submission lacked an rta (or other
optional field), passing undefined to TextInputBuilder.setValue threw
'Expected a string primitive'. Fall back to empty strings and format
rta through time_fix like the main time field.