### PR TITLE
Fix string/array validation crashes in challenge submission modal and inventory

### DIFF
--- a/src/interactions/challenge/functions.js
+++ b/src/interactions/challenge/functions.js
@@ -3499,7 +3499,7 @@ exports.currentTruguts = function (user_profile) {
 exports.randomChallengeItem = function ({ user_profile, current_challenge, db, member, coffer, sarlacc } = {}) {
     const challenges_completed = Object.values(db.ch.times).filter(time => time.user == member).length
     let item_pool = []
-    let special_items = [{ id: 'collectible_coffer' }, { id: 'trugut_boost' }, { id: 'sabotage_kit' }]
+    let special_items = ['collectible_coffer', 'trugut_boost', 'sabotage_kit'].map(id => items.find(i => i.id == id)).filter(Boolean)
     items.forEach(item => {
         if (coffer || sarlacc || (item.challenges !== null && challenges_completed > item.challenges) || current_challenge.conditions[item.condition] || item.track.includes(current_challenge.track) || item.racer.includes(current_challenge.racer)) {
             item_pool.push(item)


### PR DESCRIPTION
## Summary

Fixes two unhandled rejections in the challenge system caused by passing invalid values into discord.js builders (`@sapphire/shapeshift` validation).

### 1. Submission modal — `Expected a string primitive`
`src/interactions/challenge/modal.js`

When re-opening the submission modal for an already-submitted challenge, the stored submission's optional fields (notably `rta`) could be `undefined`. `TextInputBuilder.setValue` requires a string primitive, so it threw.

- All `setValue` calls now fall back to an empty string when the stored value is missing.
- `rta` is now formatted through `time_fix` for display consistency with the main time field.

### 2. Inventory — `Received one or more errors` (addFields)
`src/interactions/challenge/functions.js`

`randomChallengeItem` built its special-item pool from bare `{ id }` stubs lacking `name`/`description`/`rarity`. When one was awarded (e.g. by the Sarlacc when no new items remained), `new_item.description` was `undefined`, causing `EmbedBuilder.addFields` to throw. This also would have rendered "undefined undefined" in the item label.

- Special items are now resolved to their full objects from the `items` data, so they carry `name`, `description`, and `rarity`.

## Testing

These are defensive fixes addressing the exact stack traces; the data flow confirms the root cause in each case. The full live scenarios (a partial prior submission; the Sarlacc awarding a special item when no new items remain) were not reproduced in a running instance.

https://claude.ai/code/session_01MLm43LzWnUdHCeo5csmHFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLm43LzWnUdHCeo5csmHFv)_