### PR TITLE
Fix empty select menus and interaction token expiry handling

### DIFF
--- a/src/interactions/challenge.js
+++ b/src/interactions/challenge.js
@@ -51,7 +51,7 @@ module.exports = {
                 command = 'feedback'
             }
             const challenge_command = require(`./challenge/${command}.js`)
-            challenge_command[command]({ current_challenge, current_challenge_ref, interaction, args, db, database, member_id, member_avatar, user_key, user_profile, profile_ref, botto_name })
+            await challenge_command[command]({ current_challenge, current_challenge_ref, interaction, args, db, database, member_id, member_avatar, user_key, user_profile, profile_ref, botto_name })
         }
     }
 }

--- a/src/interactions/challenge/inventory.js
+++ b/src/interactions/challenge/inventory.js
@@ -299,6 +299,7 @@ exports.inventory = async function ({ interaction, user_profile, profile_ref, db
                 return
             }
 
+            const SWE1R_Guild = await interaction.client.guilds.cache.get(swe1r_guild)
             let role = await SWE1R_Guild.roles.cache.get(user_profile.roles.custom)
             role.edit({ color: color })
 
@@ -327,6 +328,7 @@ exports.inventory = async function ({ interaction, user_profile, profile_ref, db
         }
     } else if (args[2] == 'icon') {
         if (user_profile?.roles?.emoji && interaction.guild.id == swe1r_guild) {
+            const Member = await interaction.guild.members.fetch(member_id)
             Object.values(user_profile.roles.emoji).forEach(role => {
                 if (interaction.values.includes(role.id)) {
                     Member.roles.add(role.id)

--- a/src/interactions/challenge/profile.js
+++ b/src/interactions/challenge/profile.js
@@ -67,10 +67,17 @@ exports.profile = async function ({ interaction, args, db, member_id, user_profi
         }
     }
 
-    if (interaction.isChatInputCommand()) {
-        await interaction.deferReply()
-    } else {
-        await interaction.deferUpdate()
+    try {
+        if (interaction.isChatInputCommand()) {
+            await interaction.deferReply()
+        } else {
+            await interaction.deferUpdate()
+        }
+    } catch (err) {
+        // The interaction token has already expired or been acknowledged (DiscordAPIError
+        // 10062 "Unknown interaction") — usually a stale button click after a restart. There's
+        // nothing left to render to, so bail rather than throw an unhandled rejection.
+        return
     }
 
     const ach_report = achievementProgress({ db, player: member_id })
@@ -96,7 +103,7 @@ exports.profile = async function ({ interaction, args, db, member_id, user_profi
         })
         await profile_ref.child('progression').set(progression)
         let new_player_level = playerLevel(progression)
-        postMessage(client, interaction.channelId, { embeds: [new EmbedBuilder().setAuthor({ name: `${botto_name} leveled up!`, iconURL: member_avatar }).setDescription(new_player_level.string).setFooter({ text: `Level ${new_player_level.level}` })] })
+        postMessage(interaction.client, interaction.channelId, { embeds: [new EmbedBuilder().setAuthor({ name: `${botto_name} leveled up!`, iconURL: member_avatar }).setDescription(new_player_level.string).setFooter({ text: `Level ${new_player_level.level}` })] })
     }
     interaction.editReply({ embeds: [profileEmbed({ db, player: member_id, name: botto_name, avatar: member_avatar, ach_report, user_profile, stats })], components: profileComponents({ member_id, ach_report, stats, user_profile }) })
 

--- a/src/interactions/tourney/functions.js
+++ b/src/interactions/tourney/functions.js
@@ -982,6 +982,20 @@ exports.matchSelector = function ({ matches, selected } = {}) {
     return matchRow
 }
 
+// Discord rejects a StringSelectMenu with zero options (BASE_TYPE_BAD_LENGTH — options must
+// be 1-25). When the source list is empty (e.g. a tournament phase with no divisions, or no
+// active rulesets), attach a single disabled placeholder option and disable the menu instead
+// of letting the whole V2 view fail to render.
+function attachSelectOptions(selector, options, emptyLabel = 'None available') {
+    const opts = (options ?? []).filter(o => o != null)
+    if (opts.length === 0) {
+        selector.addOptions({ label: emptyLabel, value: '__none__', default: false })
+        selector.setDisabled(true)
+        return
+    }
+    selector.addOptions(...opts.slice(0, 25))
+}
+
 exports.rulesetSelector = function ({ rulesets, selected } = {}) {
     const rulesetRow = new ActionRowBuilder()
     const ruleset_selector = new StringSelectMenuBuilder()
@@ -1010,7 +1024,7 @@ exports.rulesetSelector = function ({ rulesets, selected } = {}) {
             }
         })
 
-    ruleset_selector.addOptions(...paginator({ value: selected?.[0], array: options }))
+    attachSelectOptions(ruleset_selector, paginator({ value: selected?.[0], array: options }), 'No rulesets available')
     rulesetRow.addComponents(ruleset_selector)
 
     return rulesetRow
@@ -1027,15 +1041,11 @@ exports.tourneyPhaseSelector = function ({ phases, selected } = {}) {
 
     phaseRow.addComponents(phaseSelector)
 
-    phases.forEach(phase => {
-        phaseSelector.addOptions(
-            {
-                label: phase.name,
-                value: phase.id,
-                default: selected.includes(phase.id)
-            }
-        )
-    })
+    attachSelectOptions(phaseSelector, (phases ?? []).map(phase => ({
+        label: phase.name,
+        value: phase.id,
+        default: selected.includes(phase.id)
+    })), 'No phases available')
 
     return phaseRow
 }
@@ -1051,15 +1061,11 @@ exports.tourneyDivisionSelector = function ({ divisions, selected } = {}) {
 
     divisionRow.addComponents(divisionSelector)
 
-    divisions.forEach(division => {
-        divisionSelector.addOptions(
-            {
-                label: division.name,
-                value: division.id,
-                default: selected.includes(division.id)
-            }
-        )
-    })
+    attachSelectOptions(divisionSelector, (divisions ?? []).map(division => ({
+        label: division.name,
+        value: division.id,
+        default: selected.includes(division.id)
+    })), 'No divisions available')
 
     return divisionRow
 }
@@ -1075,15 +1081,11 @@ exports.tourneyRoundSelector = function ({ rounds, selected } = {}) {
 
     roundRow.addComponents(roundSelector)
 
-    rounds.forEach(round => {
-        roundSelector.addOptions(
-            {
-                label: round.name,
-                value: round.id,
-                default: selected.includes(round.id)
-            }
-        )
-    })
+    attachSelectOptions(roundSelector, (rounds ?? []).map(round => ({
+        label: round.name,
+        value: round.id,
+        default: selected.includes(round.id)
+    })), 'No rounds available')
 
     return roundRow
 }

--- a/src/interactions/tourney/play.js
+++ b/src/interactions/tourney/play.js
@@ -294,7 +294,14 @@ async function defferInteraction(interaction, deferred, command, ephemeral = fal
                     })
                     return 1
                 }
-                const race = match.races[match.currentRace]
+                if (!matchPlayer) {
+                    await interaction.reply({
+                        content: 'Could not find that racer in this match.',
+                        ephemeral: true
+                    })
+                    return 1
+                }
+                const race = match?.races?.[match.currentRace]
                 const playerStatus = race?.players?.[matchPlayer.id]
                 const pickModal = pickRacerModal({
                     currentRace: match.currentRace,


### PR DESCRIPTION
## Summary
This PR addresses several stability issues in tournament and challenge interactions:
1. Prevents Discord API errors when select menus have zero options
2. Handles stale interaction tokens gracefully after bot restarts
3. Fixes missing null checks and variable references in match and inventory handlers

## Key Changes

- **New `attachSelectOptions()` helper** (`src/interactions/tourney/functions.js`):
  - Wraps select menu option attachment with validation
  - Adds a disabled placeholder option when the source list is empty (e.g., no divisions, no rulesets)
  - Prevents "BASE_TYPE_BAD_LENGTH" Discord API errors that occur with zero options
  - Applied to `rulesetSelector`, `tourneyPhaseSelector`, `tourneyDivisionSelector`, and `tourneyRoundSelector`

- **Interaction token expiry handling** (`src/interactions/challenge/profile.js`):
  - Wrapped `deferReply()` / `deferUpdate()` calls in try-catch
  - Gracefully returns on DiscordAPIError 10062 ("Unknown interaction") instead of throwing unhandled rejection
  - Handles stale button clicks after bot restarts

- **Match player validation** (`src/interactions/tourney/play.js`):
  - Added null check for `matchPlayer` before accessing race data
  - Returns user-friendly error message if racer not found in match
  - Added optional chaining to `match?.races?.[match.currentRace]` for safety

- **Challenge command await** (`src/interactions/challenge.js`):
  - Added `await` when calling challenge subcommands to ensure proper async handling

- **Inventory fixes** (`src/interactions/challenge/inventory.js`):
  - Added missing `SWE1R_Guild` fetch before role editing
  - Added missing `Member` fetch before role assignment in emoji section

- **API client reference** (`src/interactions/challenge/profile.js`):
  - Changed `postMessage(client, ...)` to `postMessage(interaction.client, ...)` for correct client reference

## Implementation Details
The `attachSelectOptions()` function filters null/undefined options and enforces Discord's 1-25 option limit via `slice(0, 25)`. This prevents cascading failures in the V2 tournament view when data sources are empty.

https://claude.ai/code/session_01EGp16NJtELWPCRLUMBG584