### PR TITLE
Fix NaN truguts write when settling this_or_that bets

### DIFF
--- a/src/interactions/challenge/functions.js
+++ b/src/interactions/challenge/functions.js
@@ -3475,6 +3475,11 @@ exports.initializeBounty = function (type, h, player, user_profile) {
 
 exports.manageTruguts = function ({ user_profile, profile_ref, transaction, amount, purchase } = {}) {
     console.log(`${user_profile.name} ${transaction} ${amount}`)
+    amount = Number(amount)
+    if (!Number.isFinite(amount)) {
+        console.error(`manageTruguts received invalid amount for ${user_profile.name}: ${amount} (transaction: ${transaction})`)
+        return user_profile
+    }
     if (transaction == 'w') {
         user_profile.truguts_spent += amount
     } else if (transaction == 'd') {

--- a/src/interactions/truguts.js
+++ b/src/interactions/truguts.js
@@ -114,13 +114,13 @@ module.exports = {
                         if (!outcome.paid) {
                             //pay out
                             const outcome_bets = outcome.bets ?? []
-                            const total_wrong = outcome_bets.filter(b => b.guess !== result).map(b => b.amount).reduce((a, b) => a + b, 0) ?? 0
-                            const total_right = outcome_bets.filter(b => b.guess == result).map(b => b.amount).reduce((a, b) => a + b, 0) ?? 0
+                            const total_wrong = outcome_bets.filter(b => b.guess !== result).map(b => Number(b.amount) || 0).reduce((a, b) => a + b, 0)
+                            const total_right = outcome_bets.filter(b => b.guess == result).map(b => Number(b.amount) || 0).reduce((a, b) => a + b, 0)
 
                             console.log(total_wrong, total_right)
                             outcome_bets.forEach(b => {
                                 if (b.guess == result) {
-                                    let take = Math.round((b.amount / total_right) * total_wrong)
+                                    let take = total_right > 0 ? Math.round(((Number(b.amount) || 0) / total_right) * total_wrong) : 0
                                     manageTruguts({ user_profile: db.user[b.id].random, profile_ref: userref.child(b.id).child('random'), transaction: 'd', amount: take })
                                     b.take = take
                                 } else {
@@ -137,8 +137,8 @@ module.exports = {
 
 
                         if (!outcome.paid) {
-                            const total_wrong = bet.outcomes.filter((o, i) => i !== outcome_index && o.type == 'this_or_that').map(o => o.bets).flat().map(b => b?.amount).reduce((a, b) => a + b, 0) ?? 0
-                            const total_right = bet.outcomes.filter((o, i) => i == outcome_index && o.type == 'this_or_that').map(o => o.bets).flat().map(b => b?.amount).reduce((a, b) => a + b, 0) ?? 0
+                            const total_wrong = bet.outcomes.filter((o, i) => i !== outcome_index && o.type == 'this_or_that').map(o => o.bets).flat().map(b => Number(b?.amount) || 0).reduce((a, b) => a + b, 0)
+                            const total_right = bet.outcomes.filter((o, i) => i == outcome_index && o.type == 'this_or_that').map(o => o.bets).flat().map(b => Number(b?.amount) || 0).reduce((a, b) => a + b, 0)
 
                             bet.outcomes.forEach((o, i) => {
                                 if (o.type == "this_or_that") {
@@ -146,7 +146,7 @@ module.exports = {
                                     if (o.bets) {
                                         o.bets.forEach(b => {
                                             if (o.winner) {
-                                                let take = Math.round((b.amount / total_right) * total_wrong)
+                                                let take = total_right > 0 ? Math.round(((Number(b.amount) || 0) / total_right) * total_wrong) : 0
                                                 console.log(take)
                                                 manageTruguts({ user_profile: db.user[b.id].random, profile_ref: userref.child(b.id).child('random'), transaction: 'd', amount: take })
                                                 b.take = take


### PR DESCRIPTION
## Problem

Settling a `this_or_that` bet crashed with:

```
Error: update failed: values argument contains NaN in property 'users.<id>.random.truguts_earned'
    at exports.manageTruguts (src/interactions/challenge/functions.js:3485)
    at src/interactions/truguts.js:151
```

## Root cause

The payout pool totals were summed with:

```js
.map(o => o.bets).flat().map(b => b?.amount).reduce((a, b) => a + b, 0) ?? 0
```

A losing outcome with **no `bets` array** (the normal case — nobody bet on it) contributed `undefined` to the sum, so `0 + undefined` produced `NaN`. The trailing `?? 0` can't catch it because `NaN` is neither `null` nor `undefined`. That `NaN` flowed into `take = Math.round((b.amount / total_right) * total_wrong)` and was written straight to Firebase, which rejects `NaN`.

## Fix

1. Coerce bet amounts with `Number(b?.amount) || 0` before summing, in both the `this_or_that` and `number` payout branches.
2. Guard the payout division against `total_right == 0`.
3. Add a defensive finite-amount check in `manageTruguts` so no bad computed amount from any of its ~25 call sites can corrupt the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)