### PR TITLE
Fix Discord interaction crashes: NaN payouts, modal prefill length, duplicate custom_id

### DIFF
--- a/src/interactions/challenge/modal.js
+++ b/src/interactions/challenge/modal.js
@@ -106,10 +106,17 @@ exports.modal = async function ({current_challenge, interaction, db, member_id, 
         .setRequired(false)
     if (current_challenge.submissions?.[member_id]) {
         const this_submission = db.ch.times[current_challenge.submissions[member_id].id]
-        submissionTime.setValue(time_fix(this_submission.time) || "")
+        // time_fix can produce a string longer than the field's maxLength (11) for
+        // very large stored times (e.g. a >=10h typo -> "10:00:00.000"). A prefill
+        // that exceeds maxLength makes showModal throw, so drop it back to empty.
+        const fitTime = (t) => {
+            const formatted = time_fix(t)
+            return (formatted && formatted.length <= 11) ? formatted : ""
+        }
+        submissionTime.setValue(fitTime(this_submission.time))
         submissionNotes.setValue(this_submission.notes || "")
         submissionProof.setValue(this_submission.proof || "")
-        submissionRTA.setValue(this_submission.rta ? time_fix(this_submission.rta) : "")
+        submissionRTA.setValue(this_submission.rta ? fitTime(this_submission.rta) : "")
         submissionPlatform.setValue(this_submission.platform || "")
     }
     const ActionRow1 = new ActionRowBuilder().addComponents(submissionTime)

--- a/src/interactions/tourney/functions.js
+++ b/src/interactions/tourney/functions.js
@@ -736,7 +736,7 @@ exports.optionGetters = {
     loserPool: (option, selected) => exports.getPoolOption(option, selected),
 }
 
-exports.eventSelector = function ({ event, options } = {}) {
+exports.eventSelector = function ({ event, options, index } = {}) {
     const eventRow = new ActionRowBuilder()
     const eventOptions = options?.[event.id]
     let eventQty = (event.qty == 1 ? event.type : `${event.qty} ${event.type}s`)
@@ -755,8 +755,14 @@ exports.eventSelector = function ({ event, options } = {}) {
     const rawMax = !event.qty ? 1 : (event.max || Math.min(25, optionCount))
     const maxValues = Math.max(1, rawMax)
     const minValues = Math.min(maxValues, event.optional ? 0 : (event.qty ?? 1))
+    // Append the row index as a trailing segment so the custom_id stays unique even if two
+    // active events share an id (rare same-millisecond collision in the API's id generator).
+    // event.id never contains an underscore, so play.js still reads it as args[2]; the index
+    // is a no-op disambiguator that nothing parses. Without it, a duplicate custom_id makes
+    // Discord reject the entire message (COMPONENT_CUSTOM_ID_DUPLICATED) and the view fails to render.
+    const idSuffix = index === undefined ? '' : `_${index}`
     const event_selector = new StringSelectMenuBuilder()
-        .setCustomId(`tourney_play_submitEvent_${event.id}`)
+        .setCustomId(`tourney_play_submitEvent_${event.id}${idSuffix}`)
         .setPlaceholder(placeholder)
         .setMinValues(minValues)
         .setMaxValues(maxValues)
@@ -866,8 +872,8 @@ exports.preRaceView = function ({ match, summary, options, activeEventCost, lead
     }
 
     //one action row per active event
-    events.forEach(event => {
-        container.addActionRowComponents(exports.eventSelector({ event, options }))
+    events.forEach((event, index) => {
+        container.addActionRowComponents(exports.eventSelector({ event, options, index }))
     })
 
     //force points balance, sits next to the submit-cost so the player can weigh the spend


### PR DESCRIPTION
## What changed

Three fixes for Discord interaction crashes in the challenge and tournament systems:

1. **NaN truguts write when settling this_or_that bets** (`8895d469`, already on branch) — guards against writing `NaN` to the truguts balance during bet settlement.
2. **Duplicate select-menu custom_id in tourney event selectors** (`src/interactions/tourney/functions.js`) — when two active events shared an id (rare same-millisecond collision in the API's id generator), the duplicate custom_id made Discord reject the whole pre-race message with `COMPONENT_CUSTOM_ID_DUPLICATED`. The row index is now appended as a trailing disambiguator segment.
3. **Crash when prefilling the challenge submit modal** (`src/interactions/challenge/modal.js`) — re-opening the submit modal for an existing submission prefills the time fields via `time_fix()`. For a very large stored time (e.g. a ≥10h typo → `10:00:00.000`, 12 chars) the value exceeded the field's `maxLength` of 11, so `showModal` threw `DiscordAPIError[50035] Invalid Form Body`. The prefill now falls back to empty when the formatted value won't fit.

## Why

Each of these produced an uncaught `DiscordAPIError`/write error that broke the relevant interaction for users.

## Reviewer notes

- The modal fix addresses the *symptom* (crash on re-open). The *root cause* of the oversized stored times is a separate operator-precedence bug in `src/interactions/challenge/submit.js:50` — `!current_challenge.guild == '...'` always evaluates to `false`, so the "impossible time" guard never fires and garbage times get stored. That fix is intentionally left out of this PR because it re-enables cheat rejection and changes gameplay behavior; it should be reviewed on its own.
- The `functions.js` custom_id change relies on `event.id` never containing an underscore, so existing custom_id parsing in `play.js` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)