### PR TITLE
Fix the daily reroll window sliding forward on every reroll

### DIFF
--- a/src/interactions/challenge/functions.js
+++ b/src/interactions/challenge/functions.js
@@ -1133,8 +1133,35 @@ exports.rerollReceipt = function (current_challenge, user_profile) {
     }
 }
 
+// When today's reroll window shuts, as a timestamp, or null if there's no daily
+// today yet.
+//
+// The window is a fixed two hours from the day's FIRST announcement. It has to be
+// anchored to that and not to the current challenge's own `created`, because a
+// reroll marks the old daily rerolled and posts a replacement with a fresh
+// timestamp -- so anchoring to the current one restarts the clock on every reroll
+// and lets the window slide forward all day. Every cotd posted today (the
+// original and each replacement) carries the same `day`, so the earliest of them
+// is the announcement the window should run from.
+exports.dailyRerollDeadline = function (db) {
+    const today = exports.easternTime().dayOfYear()
+    const created = Object.values(db?.ch?.challenges || {})
+        .filter(c => c && c.type == 'cotd' && c.day == today)
+        .map(c => Number(c.created))
+        .filter(Number.isFinite)
+    if (!created.length) return null
+    return Math.min(...created) + 1000 * 60 * 60 * 2
+}
+
+// Whether the daily can still be rerolled right now.
+exports.dailyRerollOpen = function (db) {
+    const deadline = exports.dailyRerollDeadline(db)
+    return deadline !== null && Date.now() < deadline
+}
+
 // Cost to reroll the Random Challenge of the Day. Starts at 📀1,000,000 and
 // doubles with each reroll performed on the same day (resets each new daily).
+// The count is server-wide, not per player.
 exports.dailyRerollCost = function (db) {
     const base = 1000000
     const today = exports.easternTime().dayOfYear()
@@ -1322,7 +1349,8 @@ exports.challengeComponents = function (current_challenge, user_profile, db) {
                 .setEmoji("⏱️")
         )
     }
-    if (db && current_challenge.type == 'cotd' && !current_challenge.rerolled && !current_challenge.completed && current_challenge.created > Date.now() - 1000 * 60 * 60 * 2) {
+    if (db && current_challenge.type == 'cotd' && !current_challenge.rerolled && !current_challenge.completed
+        && current_challenge.day == exports.easternTime().dayOfYear() && exports.dailyRerollOpen(db)) {
         row.addComponents(
             new ButtonBuilder()
                 .setCustomId("challenge_random_reroll")

--- a/src/interactions/challenge/shop/rerolldaily.js
+++ b/src/interactions/challenge/shop/rerolldaily.js
@@ -1,13 +1,15 @@
-const { updateChallenge, dailyChallenge, dailyRerollCost, manageTruguts } = require('../functions.js');
+const { updateChallenge, dailyChallenge, dailyRerollCost, dailyRerollOpen, manageTruguts } = require('../functions.js');
 const { editMessage } = require('../../../discord.js');
 const { number_with_commas } = require('../../../generic.js');
 
 const { EmbedBuilder } = require('discord.js');
 
 exports.rerolldaily = async function ({ interaction, current_challenge, db, database, botto_name, user_profile, profile_ref } = {}) {
-    //the daily can only be rerolled within two hours of being posted
+    //the daily can only be rerolled for two hours after the day's FIRST
+    //announcement - dailyRerollOpen anchors to that rather than to whichever
+    //replacement is currently up, so rerolling can't push the window forward
     let last = current_challenge ?? Object.values(db.ch.challenges).filter(c => c.type == 'cotd' && !c.rerolled).sort((a, b) => a.created - b.created).pop()
-    if (!last || last.type !== 'cotd' || last.rerolled || last.completed || last.created < Date.now() - 1000 * 60 * 60 * 2) {
+    if (!last || last.type !== 'cotd' || last.rerolled || last.completed || !dailyRerollOpen(db)) {
         const tooLate = new EmbedBuilder()
             .setTitle("<:WhyNobodyBuy:589481340957753363> It's too late...")
             .setDescription("You can only reroll the random challenge of the day within 2 hours of its announcement.")


### PR DESCRIPTION
Follow-up to #23 — this commit was pushed a few minutes after that PR merged, so it missed the train. Everything else from that branch landed.

## The bug

The reroll window is meant to be a single fixed two hours from the day's announcement. It wasn't.

The guard compared against the **current** challenge's own `created`. But a reroll marks the old daily `rerolled` and posts a *replacement* with a fresh timestamp — so every reroll restarted the clock. Reroll at 1h59m and you had until 3h59m to go again, and you could keep chaining that through the day. The only thing actually stopping it was the doubling cost.

## The fix

Adds `dailyRerollDeadline` / `dailyRerollOpen`, anchored to the **earliest** cotd carrying today's `day` — the original announcement — so replacements can't move it. Every cotd posted today, original and replacements alike, shares the same `day`, so the earliest is the right anchor and no schema change or migration is needed.

Both call sites now use it. The button on the challenge embed had the same sliding comparison written inline and would have kept offering itself after the window shut.

The button also gains an explicit "is this today's daily" check. The old `created > now - 2h` comparison did that implicitly; the window check alone does not, so without it an old cotd re-rendered during today's window would sprout a reroll button.

## Verified

Against the exact failure case — original posted 2h05m ago, replacement 10 minutes old — the window now reads **closed**, where before it stayed open.

Also covered: chained rerolls inside one window still work; the deadline stays stable across rerolls; 1h59m open / 2h01m closed; yesterday's cotd only; no cotd today; and missing/undefined db shapes return closed rather than throwing. 14 assertions, all passing. Both files pass `node --check`.

Cost behaviour is unchanged — still 📀1,000,000 doubling per reroll, counted server-wide, resetting at midnight ET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)