### PR TITLE
Restore the random challenge leaderboard

### DIFF
--- a/src/commands/challenge.js
+++ b/src/commands/challenge.js
@@ -28,6 +28,11 @@ module.exports = {
         )
         .addSubcommand(subcommand =>
             subcommand
+                .setName('leaderboard')
+                .setDescription('Browse the best random challenge times by track, conditions, and pod')
+        )
+        .addSubcommand(subcommand =>
+            subcommand
                 .setName('map')
                 .setDescription('Visualize a map of every possible challenge')
         ),

--- a/src/interactions/challenge/functions.js
+++ b/src/interactions/challenge/functions.js
@@ -2025,8 +2025,16 @@ exports.menuComponents = function () {
     //         .setEmoji('⚙️')
     // )
 
+    const row2 = new ActionRowBuilder()
+        .addComponents(
+            new ButtonBuilder()
+                .setCustomId("challenge_random_leaderboard")
+                .setLabel("Leaderboard")
+                .setStyle(ButtonStyle.Secondary)
+                .setEmoji('🏆')
+        )
 
-    return [row1]
+    return [row1, row2]
 }
 
 exports.shopOptions = function ({ user_profile, player, db, selection } = {}) {

--- a/src/interactions/challenge/leaderboard.js
+++ b/src/interactions/challenge/leaderboard.js
@@ -1,270 +1,239 @@
+const { racers } = require('../../data/sw_racer/racer.js')
 const { tracks } = require('../../data/sw_racer/track.js')
 const { circuits } = require('../../data/sw_racer/circuit.js')
 const { planets } = require('../../data/sw_racer/planet.js')
 
-const { EmbedBuilder } = require('discord.js');
+const { console_emojis } = require('../../data/discord/emoji.js')
+const { time_fix, randomErrorMessage } = require('../../generic.js')
 
-exports.leaderboard = async function ({ interaction } = {}) {
-    const unAvailable = new EmbedBuilder()
-        .setTitle("<:WhyNobodyBuy:589481340957753363> I have great faith in the boy")
-        .setDescription("Leaderboards are currently unavailable. Please harass LightningPirate to get this feature updated.")
-    interaction.reply({ embeds: [unAvailable], ephemeral: true })
-    return
-    const challengeLeaderboard = new EmbedBuilder()
-    var track = Math.floor(Math.random() * 25)
-    var conditions = []
-    var pods = []
-    var showall = false
-    //filters out other tracks
-    if (!args.includes("initial")) {
-        for (var i = 0; i < interaction.message.components[0].components[0].options.length; i++) { //track
-            var option = interaction.message.components[0].components[0].options[i]
-            if (option.hasOwnProperty("default")) {
-                if (option.default) {
-                    track = i
-                }
-            }
-        }
-        for (var i = 0; i < interaction.message.components[1].components[0].options.length; i++) { //conditions
-            var option = interaction.message.components[1].components[0].options[i]
-            if (option.hasOwnProperty("default")) {
-                if (option.default) {
-                    conditions.push(option.value)
-                }
-            }
-        }
-        for (var i = 0; i < interaction.message.components[2].components[0].options.length; i++) { //pods
-            var option = interaction.message.components[2].components[0].options[i]
-            if (option.hasOwnProperty("default")) {
-                if (option.default) {
-                    pods.push(String(i))
-                }
-            }
-        }
-        if (args[2] == "track") {
-            track = Number(interaction.data.values[0])
-        } else if (args[2] == "conditions") {
-            if (interaction.data.hasOwnProperty("values")) {
-                conditions = interaction.data.values
-            }
-        } else if (args[2] == "pods") {
-            if (interaction.data.hasOwnProperty("values")) {
-                pods = interaction.data.values
-            } else {
-                pods = []
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, StringSelectMenuBuilder } = require('discord.js');
+
+const die_icon = "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/twitter/282/game-die_1f3b2.png"
+const playable_racers = 23
+const positions = ["<:P1:671601240228233216>", "<:P2:671601321257992204>", "<:P3:671601364794605570>", "4th", "5th", "6th", "7th", "8th", "9th", "10th"]
+
+// Every option in the Conditions select. Keys sharing a `group` are alternatives:
+// picking none of a group means "either" rather than "nothing matches". The
+// groups listed in `filter_groups` below describe the run itself; the rest
+// (My Runs Only, Has Proof) just narrow the list and are handled on their own.
+const condition_options = {
+    mu: { label: "Upgrades", group: "nu", match: false },
+    nu: { label: "No Upgrades", group: "nu", match: true },
+    ft: { label: "Full Track", group: "skips", match: false },
+    skips: { label: "Skips", group: "skips", match: true },
+    unmirr: { label: "Unmirrored", group: "mirror", match: false },
+    mirr: { label: "Mirrored", group: "mirror", match: true },
+    fwd: { label: "Forward", group: "backwards", match: false },
+    bwd: { label: "Backwards", group: "backwards", match: true },
+    lap1: { label: "1-Lap", group: "laps", match: 1 },
+    lap2: { label: "2-Laps", group: "laps", match: 2 },
+    lap3: { label: "3-Laps", group: "laps", match: 3 },
+    lap4: { label: "4-Laps", group: "laps", match: 4 },
+    lap5: { label: "5-Laps", group: "laps", match: 5 },
+    proof: { label: "Has Proof", group: "proof" },
+    user: { label: "My Runs Only", group: "user" }
+}
+
+const default_conditions = ["mu", "nu", "ft", "skips", "unmirr", "mirr", "fwd", "bwd", "lap3"]
+
+// The filters live in the message's own select menus rather than in the database -
+// whatever is marked default on the message is the current state.
+function currentSelection(interaction, suffix) {
+    for (const row of interaction.message?.components ?? []) {
+        for (const component of row.components ?? []) {
+            if (component.customId == `challenge_random_leaderboard_${suffix}`) {
+                return (component.options ?? []).filter(option => option.default).map(option => option.value)
             }
         }
     }
-    if (conditions.length == 0) {
-        conditions = ["mu", "nu", "ft", "skips", "unmirr", "mirr", "lap3"]
+    return null
+}
+
+exports.leaderboard = async function ({ interaction, args, db, member_id } = {}) {
+    const changed = args[2]
+
+    //track - opens on a random one, the way a random challenge would roll it
+    let track = Math.floor(Math.random() * tracks.length)
+    const selected_track = Number((changed == "track" ? interaction.values : currentSelection(interaction, "track"))?.[0])
+    if (tracks[selected_track]) {
+        track = selected_track
     }
-    //prepare filters
-    var nu = [], skips = [], mirrored = [], laps = [], user = null
-    if (conditions.includes("mu")) {
-        nu.push(false)
-    }
-    if (conditions.includes("nu")) {
-        nu.push(true)
-    }
-    if (conditions.includes("ft")) {
-        skips.push(false)
-    }
-    if (conditions.includes("skips")) {
-        skips.push(true)
-    }
-    if (conditions.includes("unmirr")) {
-        mirrored.push(false)
-    }
-    if (conditions.includes("mirr")) {
-        mirrored.push(true)
-    }
-    if (conditions.includes("lap1")) {
-        laps.push(1)
-    }
-    if (conditions.includes("lap2")) {
-        laps.push(2)
-    }
-    if (conditions.includes("lap3")) {
-        laps.push(3)
-    }
-    if (conditions.includes("lap4")) {
-        laps.push(4)
-    }
-    if (conditions.includes("lap5")) {
-        laps.push(5)
-    }
-    if (conditions.includes("user")) {
-        user = member_id
-    }
-    //account for missing values
-    if (nu.length == 0) { nu.push(true, false), conditions.push("mu", "nu") }
-    if (skips.length == 0) { skips.push(true, false), conditions.push("ft", "skips") }
-    if (mirrored.length == 0) { mirrored.push(true, false), conditions.push("unmirr", "mirr") }
-    if (laps.length == 0) { laps.push(1, 2, 3, 4, 5), conditions.push("lap1", "lap2", "lap3", "lap4", "lap5") }
-    //filter
-    var challenge = Object.values(db.ch.challenges)
-    var challengefiltered = challenge.filter(element => element.track == track)
-    challengefiltered = challengefiltered.filter(element => skips.includes(element.skips))
-    challengefiltered = challengefiltered.filter(element => nu.includes(element.nu))
-    challengefiltered = challengefiltered.filter(element => laps.includes(element.laps))
-    challengefiltered = challengefiltered.filter(element => mirrored.includes(element.mirror))
-    if (pods.length > 0) {
-        challengefiltered = challengefiltered.filter(element => pods.includes(String(element.racer)))
-    }
-    if (user !== null) {
-        challengefiltered = challengefiltered.filter(element => element.user == user)
-    }
-    challengefiltered.sort(function (a, b) {
-        return a.time - b.time;
+
+    //conditions - copied, since the refill below writes back into it
+    const conditions = [...((changed == "conditions" ? interaction.values : currentSelection(interaction, "conditions")) ?? default_conditions)]
+
+    //pods
+    const pods = (changed == "pods" ? interaction.values : currentSelection(interaction, "pods")) ?? []
+
+    //build the filters, and fill any group the user emptied back in so the menu
+    //keeps matching what the leaderboard is actually showing
+    const groups = { nu: [], skips: [], mirror: [], backwards: [], laps: [] }
+    Object.keys(condition_options).forEach(key => {
+        const option = condition_options[key]
+        if (groups[option.group] && conditions.includes(key)) {
+            groups[option.group].push(option.match)
+        }
     })
-    //construct embed
-    challengeLeaderboard
-        .setAuthor("Random Challenge", "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/twitter/282/game-die_1f3b2.png")
-        .setTitle(planets[tracks[track].planet].emoji + " " + tracks[track].name)
-        .setColor(planets[tracks[track].planet].color)
-        .setDescription(circuits[tracks[track].circuit].name + " Circuit | Race " + tracks[track].cirnum + " | " + planets[tracks[track].planet].name)
-        .setFooter({ text: challengefiltered.length + " Total Runs" })
-    if (user !== null) {
-        challengeLeaderboard.setAuthor(Member.user.username + "'s Best", client.guilds.resolve(interaction.guildId).members.resolve(user).user.avatarURL())
-        showall = true
-    }
-    var pos = ["<:P1:671601240228233216>", "<:P2:671601321257992204>", "<:P3:671601364794605570>", "4th", "5th"]
-    var already = []
-    if (challengefiltered.length > 0) {
-        for (var j = 0; j < challengefiltered.length; j++) {
-            if (!already.includes((challengefiltered[j].player + " " + challengefiltered[j].skips + " " + challengefiltered[j].racer + " " + challengefiltered[j].nu + " " + challengefiltered[j].laps + " " + challengefiltered[j].mirror)) || showall) {
-                var stuff = []
-                stuff.push(challengefiltered[j].laps + " Laps")
-                var upgr = " | MU"
-                if (challengefiltered[j].skips == true) {
-                    stuff.push("Skips")
-                } else {
-                    stuff.push("FT")
-                }
-                if (challengefiltered[j].nu == true) {
-                    upgr = " | NU"
-                }
-                if (challengefiltered[j].mirror == true) {
-                    stuff.push("Mirrored")
-                }
-                var character = racers[challengefiltered[j].racer].flag //+ " " + racers[challengefiltered[j].racer].name
-                challengeLeaderboard
-                    .addField(pos[0] + " " + challengefiltered[j].name, stuff.join(" | "), true)
-                    .addField(tools.timefix(Number(challengefiltered[j].time).toFixed(3)), " " + character + upgr, true)
-                    .addField('\u200B', '\u200B', true)
-                already.push(challengefiltered[j].player + " " + challengefiltered[j].skips + " " + challengefiltered[j].racer + " " + challengefiltered[j].nu + " " + challengefiltered[j].laps + " " + challengefiltered[j].mirror)
-                if (pos.length > 1) {
-                    pos.splice(0, 1)
-                } else {
-                    j = challengefiltered.length
-                }
-            }
+    Object.keys(groups).forEach(group => {
+        if (groups[group].length) {
+            return
         }
-    } else {
-        challengeLeaderboard
-            .addField("<:WhyNobodyBuy:589481340957753363> No Runs", "`No runs were found matching that criteria`\n" + errorMessage[Math.floor(Math.random() * errorMessage.length)])
-    }
-    //construct components
+        Object.keys(condition_options).filter(key => condition_options[key].group == group).forEach(key => {
+            groups[group].push(condition_options[key].match)
+            conditions.push(key)
+        })
+    })
+    const mine = conditions.includes("user")
+    const proven = conditions.includes("proof")
 
-    var cond = { mu: "Upgrades", nu: "No Upgrades", ft: "Full Track", skips: "Skips", unmirr: "Unmirrored", mirr: "Mirrored", lap1: "1-Lap", lap2: "2-Laps", lap3: "3-Laps", lap4: "4-Laps", lap5: "5-Laps", user: "My Runs Only" }
-    var track_selections = []
-    var racer_selections = []
-    var cond_selections = []
-    for (var i = 0; i < 25; i++) {
-        var racer_option = {
-            label: racers[i].name,
-            value: i,
-            description: racers[i].pod.substring(0, 50),
-            emoji: {
-                name: racers[i].flag.split(":")[1],
-                id: racers[i].flag.split(":")[2].replace(">", "")
-            }
+    //filter runs
+    const runs = Object.values(db.ch.times ?? {}).filter(run => {
+        if (Array.isArray(run.track)) { //multi-track monthly challenges have no place on a track board
+            return false
         }
-        if (pods.includes(String(i))) {
-            racer_option.default = true
+        const c = run.conditions ?? run //a handful of the oldest runs store conditions flat
+        return Number(run.track) === track
+            && groups.nu.includes(Boolean(c.nu))
+            && groups.skips.includes(Boolean(c.skips))
+            && groups.mirror.includes(Boolean(c.mirror))
+            && groups.backwards.includes(Boolean(c.backwards))
+            && groups.laps.includes(Number(c.laps))
+            && (!pods.length || pods.includes(String(run.racer)))
+            && (!mine || run.user == member_id)
+            && (!proven || Boolean(run.proof))
+    }).sort((a, b) => a.time - b.time)
+
+    //one entry per player per exact challenge, unless the player asked for all of their own runs
+    const shown = []
+    const seen = new Set()
+    runs.forEach(run => {
+        if (shown.length >= positions.length) {
+            return
         }
-        var track_option = {
-            label: tracks[i].name.replace("The Boonta Training Course", "Boonta Training Course"),
-            value: i,
-            description: (circuits[tracks[i].circuit].name + " Circuit | Race " + tracks[i].cirnum + " | " + planets[tracks[i].planet].name).substring(0, 50),
-            emoji: {
-                name: planets[tracks[i].planet].emoji.split(":")[1],
-                id: planets[tracks[i].planet].emoji.split(":")[2].replace(">", "")
-            }
+        const c = run.conditions ?? run
+        const key = [run.user, run.racer, c.laps, Boolean(c.skips), Boolean(c.nu), Boolean(c.mirror), Boolean(c.backwards)].join("|")
+        if (!mine && seen.has(key)) {
+            return
         }
-        if (track == i) {
-            track_option.default = true
+        seen.add(key)
+        shown.push(run)
+    })
+
+    //names change over time - prefer the player's current one over the one stored on the run
+    const names = {}
+    Object.values(db.user).forEach(user => {
+        if (user.discordID) {
+            names[user.discordID] = user.random?.name ?? user.name
         }
-        if (i < 23) {
-            racer_selections.push(racer_option)
-        }
-        track_selections.push(track_option)
-        var condkeys = Object.keys(cond)
-        if (i < condkeys.length) {
-            var cond_option = {
-                label: cond[condkeys[i]],
-                value: condkeys[i],
-            }
-            if (conditions.includes(condkeys[i])) {
-                cond_option.default = true
-            }
-            cond_selections.push(cond_option)
-        }
+    })
+
+    //laid out like the challenge card's leaderboard: time, pod, name, console,
+    //then this run's conditions as their own code blocks
+    const lines = shown.map((run, i) => {
+        const c = run.conditions ?? run
+        const time = `**\`${time_fix(run.time)}\`**`
+        const tags = [
+            `${c.laps} Lap${Number(c.laps) == 1 ? '' : 's'}`,
+            c.skips ? 'Skips' : 'FT',
+            c.nu ? 'NU' : 'MU',
+            c.mirror ? 'Mirrored' : null,
+            c.backwards ? 'Backwards' : null
+        ].filter(e => e).map(tag => `\`${tag}\``).join(" ")
+        return [
+            positions[i],
+            run.proof ? `[${time}](<${run.proof}>)` : time,
+            racers[run.racer]?.flag.trim(), //one of the flags carries a stray trailing space
+            names[run.user] ?? run.name ?? 'no name',
+            console_emojis[run.platform],
+            tags
+        ].filter(e => e).join(" ")
+    })
+
+    //construct embed
+    const planet = planets[tracks[track].planet]
+    const challengeLeaderboard = new EmbedBuilder()
+        .setAuthor({ name: "Random Challenge", iconURL: die_icon })
+        .setTitle(`${planet.emoji} ${tracks[track].name}`)
+        .setColor(planet.color)
+        .setDescription([
+            `${circuits[tracks[track].circuit].name} Circuit | Race ${tracks[track].cirnum} | ${planet.name}`,
+            lines.length ? lines.join("\n") : `**No Runs**\n\`No runs were found matching that criteria\`\n${randomErrorMessage()}`
+        ].join("\n\n"))
+        .setFooter({ text: `${runs.length} Total Run${runs.length == 1 ? '' : 's'}` })
+
+    if (mine) {
+        challengeLeaderboard.setAuthor({
+            name: `${interaction.member?.displayName ?? interaction.user.username}'s Best`,
+            iconURL: interaction.member?.displayAvatarURL() ?? interaction.user.displayAvatarURL()
+        })
     }
-    components.push(
-        {
-            type: 1,
-            components: [
-                {
-                    type: 3,
-                    custom_id: "challenge_random_leaderboards_track",
-                    options: track_selections,
-                    placeholder: "Select Track",
-                    min_values: 1,
-                    max_values: 1
-                },
-            ]
-        },
-        {
-            type: 1,
-            components: [
-                {
-                    type: 3,
-                    custom_id: "challenge_random_leaderboards_conditions",
-                    options: cond_selections,
-                    placeholder: "Select Conditions",
-                    min_values: 0,
-                    max_values: cond_selections.length
-                },
-            ]
-        },
-        {
-            type: 1,
-            components: [
-                {
-                    type: 3,
-                    custom_id: "challenge_random_leaderboards_pods",
-                    options: racer_selections,
-                    placeholder: "Select Pods",
-                    min_values: 0,
-                    max_values: racer_selections.length
-                }
-            ]
-        },
-        {
-            type: 1,
-            components: [
-                {
-                    type: 2,
-                    style: 2,
-                    custom_id: "challenge_random_menu",
-                    emoji: {
-                        name: "menu",
-                        id: "862620287735955487"
-                    }
-                }
-            ]
-        }
-    )
-    interaction.editReply({ embeds: [challengeLeaderboard], components: components })
+
+    //construct components
+    const track_selector = new StringSelectMenuBuilder()
+        .setCustomId("challenge_random_leaderboard_track")
+        .setPlaceholder("Select Track")
+        .setMinValues(1)
+        .setMaxValues(1)
+    tracks.forEach((t, i) => {
+        track_selector.addOptions({
+            label: t.name.replace("The Boonta Training Course", "Boonta Training Course"),
+            value: String(i),
+            description: `${circuits[t.circuit].name} Circuit | Race ${t.cirnum} | ${planets[t.planet].name}`.substring(0, 50),
+            emoji: {
+                name: planets[t.planet].emoji.split(":")[1],
+                id: planets[t.planet].emoji.split(":")[2].replace(">", "")
+            },
+            default: track == i
+        })
+    })
+
+    const condition_selector = new StringSelectMenuBuilder()
+        .setCustomId("challenge_random_leaderboard_conditions")
+        .setPlaceholder("Select Conditions")
+        .setMinValues(0)
+        .setMaxValues(Object.keys(condition_options).length)
+    Object.keys(condition_options).forEach(key => {
+        condition_selector.addOptions({
+            label: condition_options[key].label,
+            value: key,
+            default: conditions.includes(key)
+        })
+    })
+
+    const pod_selector = new StringSelectMenuBuilder()
+        .setCustomId("challenge_random_leaderboard_pods")
+        .setPlaceholder("Select Pods")
+        .setMinValues(0)
+        .setMaxValues(playable_racers)
+    racers.slice(0, playable_racers).forEach((racer, i) => {
+        const flag = racer.flag.trim().split(":")
+        pod_selector.addOptions({
+            label: racer.name,
+            value: String(i),
+            description: racer.pod.substring(0, 50),
+            emoji: {
+                name: flag[1],
+                id: flag[2].replace(">", "")
+            },
+            default: pods.includes(String(i))
+        })
+    })
+
+    const components = [
+        new ActionRowBuilder().addComponents(track_selector),
+        new ActionRowBuilder().addComponents(condition_selector),
+        new ActionRowBuilder().addComponents(pod_selector),
+        new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId("challenge_random_menu")
+                .setStyle(ButtonStyle.Secondary)
+                .setEmoji("862620287735955487")
+        )
+    ]
+
+    if (interaction.isChatInputCommand()) {
+        interaction.reply({ embeds: [challengeLeaderboard], components })
+    } else { //navigate in place, the way the shop and inventory do
+        interaction.update({ embeds: [challengeLeaderboard], components })
+    }
 }


### PR DESCRIPTION
## What

Brings back `/challenge leaderboard` — the filterable board of the fastest random challenge times on a given track.

## Why it was broken

`src/interactions/challenge/leaderboard.js` opened with a hardcoded *"Leaderboards are currently unavailable. Please harass LightningPirate to get this feature updated"* reply followed by `return`. Everything after it was discord.js v12 code written against a data model that no longer exists — `addField`, positional `setAuthor`, `interaction.data.values`, and free references to `args` / `db` / `racers` / `tools` / `components` / `errorMessage` that were never in scope. It could not have run even without the early return.

Nothing pointed at it either: the select custom_ids said `challenge_random_leaderboard**s**_*`, which the router in `src/interactions/challenge.js` would have tried to `require` as `./challenge/leaderboards.js`, and no button or subcommand existed.

## What changed

**Rewritten for v14 against the current data model.** Runs in `challenge/times` keep their ruleset under `run.conditions`, so the filters read from there, with a fallback to the flat fields a handful of the oldest rows still use. The 41 multi-track monthly (COTM) rows are excluded — they have no place on a per-track board.

**Row layout matches the challenge card's leaderboard** (`challengeLeaderboardV2`): position, time, pod, name, console, then each of that run's conditions in its own code block. The per-row conditions matter here in a way they don't on a challenge card, since one board can mix lap counts and rulesets:

```
<:P1:…> **`42.432`** <:mars:…> Domirae <:pc:…> `3 Laps` `Skips` `MU`
```

Times are bold code blocks and wrap the proof link when a run has one. Ten fastest, one row per player per exact challenge.

**Filters** — track, conditions, and pods. Filter state lives in the message's own select menus rather than the database, so the view is stateless. Conditions work as an allow-list per group (upgrades, skips, mirror, direction, laps); emptying a group fills it back in so the menu keeps matching what's actually displayed. Two options sit outside the groups and simply narrow the list: **My Runs Only** and **Has Proof**. **Forward / Backwards** are new — `conditions.backwards` didn't exist when this view was originally written.

**Entry points** — a Leaderboard button on the challenge menu (new second row) and `/challenge leaderboard`. The button navigates in place and the back button returns to the menu, matching how the shop and inventory already behave.

## Verified

Exercised against the live database (12,669 times, 438 users) rather than only fixtures:

- Boonta Training Course, default filters → 563 matching runs, correct top 10
- All conditions → 698 runs, mixed lap counts and mirror/backwards rows render correctly
- 3 laps + Has Proof → 45 runs, every row carries a linked time (YouTube and Discord attachments both count)
- All 41 array-track COTM rows excluded; zero rows in the live set are missing `.conditions`
- Filter state round-trips through the message across track → conditions → pods clicks; embeds are ~1.1KB, well under the 4096 limit; all builder payloads pass v14 validation

Re-ran the same checks against this exact commit on top of `master` before pushing.

Also caught in passing: Wan Sandage's `flag` in `src/data/sw_racer/racer.js` carries a trailing space, which produced a double space in rows and a whitespace-tainted emoji id in the pod menu. Trimmed locally here. **The same bug exists in the shared `racerSelector` in `functions.js`** (used by `/lookup` and the profile view) — left alone, worth a separate look.

## Reviewer note

`/challenge leaderboard` needs a command deploy to appear; the menu button works without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
