### PR TITLE
Return Discord's access token as well as our own

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -85,8 +85,9 @@ exports.tokenHandler = ctx => async function (req, res) {
         return res.status(400).json({ error: 'Missing code.' });
     }
     let discordUser;
+    let discordToken;
     try {
-        ({ user: discordUser } = await exchange(code));
+        ({ user: discordUser, access: discordToken } = await exchange(code));
     } catch (err) {
         // Discord's own message is not something to hand a browser verbatim, and a failed
         // exchange is a failed exchange whatever the reason.
@@ -99,7 +100,15 @@ exports.tokenHandler = ctx => async function (req, res) {
 
     const token = jwt.sign({ discordId: discordUser.id, userKey }, JWT_SECRET, { expiresIn: TOKEN_TTL });
     return res.json({
+        // Ours, for this API. Signed with CUBE_JWT_SECRET and meaningless to anyone else.
         token,
+        // **Discord's**, for `sdk.commands.authenticate()`. The SDK hands it straight back to
+        // Discord, which validates it against `/oauth2/@me` — so our JWT cannot stand in for it,
+        // and passing one there is a 401 every time.
+        //
+        // Returning it is the documented flow rather than a leak: the client is what obtained the
+        // code in the first place, and the scope is `identify` and nothing else.
+        accessToken: discordToken,
         user: {
             id: discordUser.id,
             username: name,


### PR DESCRIPTION
`sdk.commands.authenticate()` takes **Discord's** OAuth2 access token, not ours — the SDK hands it straight back to Discord, which validates it against `/oauth2/@me`. The Activity was passing the JWT this endpoint mints, which Discord has no idea about, so the handshake ended on:

```
GET https://discord.com/api/v9/oauth2/@me 401 (Unauthorized)
```

with the boot screen stuck on `finishing up…`.

The exchange already had the right token and was throwing it away. Both come back now, named for what they are: `token` is ours and carries every request to this API, `accessToken` is Discord's and is only ever handed to the SDK.

Returning Discord's to the client is the documented flow rather than a leak — the client is what obtained the code to begin with, and the scope is `identify` and nothing else.

Needs the matching junkyard change (`chance-cube-activity`), already deployed. Neither half works alone.

`cubeApiSmoke` 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)