### PR TITLE
Keep a bust on file when a reroll can replay it

### DIFF
--- a/docs/chance-cube.md
+++ b/docs/chance-cube.md
@@ -809,9 +809,16 @@ Two faces are the price of all that, and they are on the cubes that pay best:
 **A shatter is the wipeout's job and nothing else's.** The Reroll Cube briefly shattered *itself* on
 every payout, as a brake on how often it could bank — which worked, and cost the cube its own
 identity: it reported a shatter every single time it did its job, and never once showed the face
-that actually breaks it. The brake is a wipeout face now, one in six, exactly like the other three
-cubes that carry one. Anything the shatter line names has genuinely been destroyed, and it draws as
-the wipeout, because that is what happened to it.
+that actually breaks it. The brake is a wipeout face now — **two** in six, as on the Multiplier;
+Shmi and Anakin carry one apiece. Anything the shatter line names has genuinely been destroyed, and
+it draws as the wipeout, because that is what happened to it.
+
+**The variant table further down predates this brake and has not been re-measured against it.** Its
+shipped row is `2 Ratts, cracks` — four banking faces, two Ratts, and the reroll face spending the
+cube on payout. What ships now is three banking faces, one Ratts and two wipeouts, which is a third
+distribution again: the once-per-run cap survived the redesign but is enforced by a face the player
+can see rather than by the payout, and the EV of that has never been simulated. Read `tuning.js` for
+what the cube does; treat **1.72** as the number for a cube that no longer exists.
 
 Resolution is **two passes over the line**, because a cube's own side has to be settled before
 anything starts copying or fusing cubes around it: first every face that decides a side or sets a

--- a/scripts/cubeApiSmoke.js
+++ b/scripts/cubeApiSmoke.js
@@ -194,6 +194,14 @@ const check = function (name, ok, detail) {
     check('roll reports abstract ids, not emoji',
         !/<a?:[a-zA-Z0-9_]+:\d+>/.test(JSON.stringify(roll || {})), JSON.stringify(roll?.line));
     check('roll carries the board with it', typeof roll?.board?.balance === 'number', JSON.stringify(roll?.board));
+    // The two totals the count walk cannot derive from `line`. Both pay in the first pass and can be
+    // written over in the second, so a client left to count the faces it can still see undercounts —
+    // while the readout moves anyway, off the settled board, with nothing on screen to explain it.
+    // Typed even at zero: to a client reading `|| 0`, a missing field and "banked none" are the same
+    // answer, and this is the check that tells them apart.
+    check('roll reports what it banked, not just the faces it kept',
+        typeof roll?.rerolls === 'number' && typeof roll?.shortcut === 'boolean',
+        `rerolls ${JSON.stringify(roll?.rerolls)}, shortcut ${JSON.stringify(roll?.shortcut)}`);
     check('the stake left the balance',
         roll?.board?.balance === before - stakeNow + (roll?.settled?.outcome === 'bank' ? roll.settled.standing : 0),
         `balance ${roll?.board?.balance}, before ${before}, stake ${stakeNow}, outcome ${roll?.settled?.outcome}`);
@@ -208,6 +216,10 @@ const check = function (name, ok, detail) {
         check('a bust leaves no live run', roll.board.run === null, JSON.stringify(roll.board.run));
         check('a bust reports why', ['bust', 'ratts', 'cackle', 'tie'].includes(roll.settled.reason),
             roll.settled.reason);
+        // Checked against the mirror, not `board.run`: a dead node also reads as no live run, so the
+        // board cannot tell "cleared" from "kept on file".
+        check('a bust with no reroll banked leaves no node at all',
+            db.ch.cube.ladders['d-KEY'] === undefined, JSON.stringify(db.ch.cube.ladders['d-KEY']));
     }
 
     // Whatever happened, the ledger has to reconcile against the balance that moved.
@@ -245,6 +257,38 @@ const check = function (name, ok, detail) {
     check(won ? 'a live win leaves the pot alone' : 'a bust feeds the pot',
         won ? !touchedPot : touchedPot,
         JSON.stringify([...new Set(writes.map(w => w.path))]));
+
+    // --- a dead run is something a reroll can replay --------------------------
+    //
+    // **Must stay last:** the pot audit above reads the whole `writes` array, and a reroll always moves
+    // the pot — reversing the bust takes `potCut(stake)` back out.
+    //
+    // Guards the field names, which are the whole contract between `settleLoss` writing this node and
+    // `spendReroll` reading it back: rename one and the reroll silently replays the wrong table.
+    // Seeded rather than played, because whether a real roll busts is a coin flip. Three plain cubes,
+    // so the throw is an odd count and can never park on a tie.
+    PLAYER.random.cube.rerolls = 1;
+    db.ch.cube.ladders['d-KEY'] = {
+        stake: 1000, standing: 0, level: 1, call: 'blue', mult: 0, spent: [],
+        set: [0, 0, 0], bag: [0],
+        faces: ['side:blue', 'side:red', 'side:blue'], roll: ['blue', 'red', 'blue'],
+        reason: 'bust', dead: true,
+    };
+    r = await call('GET', '/cube/state', { auth: t });
+    check('a dead run is reported as dead, not as live',
+        r.json?.run === null && r.json?.dead?.level === 1,
+        `run ${JSON.stringify(r.json?.run)}, dead ${JSON.stringify(r.json?.dead?.level)}`);
+
+    r = await call('POST', '/cube/reroll', { auth: t, body: {} });
+    check('reroll replays a dead run', r.status === 200 && Array.isArray(r.json?.thrown),
+        `${r.status} ${r.text}`);
+    check('reroll replays the same level', r.json?.level === 1, JSON.stringify(r.json?.level));
+    check('reroll throws the stored table rather than drawing a new one',
+        r.json?.thrown?.length === 3, JSON.stringify(r.json?.thrown));
+    check('reroll spends the banked stock', r.json?.board?.player?.rerolls === 0,
+        JSON.stringify(r.json?.board?.player?.rerolls));
+    check('a spent reroll leaves nothing further to reroll',
+        !r.json?.board?.dead, JSON.stringify(r.json?.board?.dead));
 
     server.close();
     const failed = results.filter(x => !x.ok);

--- a/scripts/cubeDevToken.js
+++ b/scripts/cubeDevToken.js
@@ -7,8 +7,8 @@
 //
 // Read-only — it reads the mirror and signs a JWT. Nothing is written.
 //
-//   node scripts/cubeDevToken.js                 # first player who owns the cube
-//   node scripts/cubeDevToken.js <discordId>     # a specific one
+//   node scripts/cubeDevToken.js                 # the dev user
+//   node scripts/cubeDevToken.js <discordId>     # someone else
 //
 // Then:
 //   curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:3030/cube/state
@@ -24,7 +24,10 @@ console.log = (...args) => console.error(...args);
 const jwt = require('jsonwebtoken');
 const { db } = require('../src/firebase.js');
 
-const WANTED = process.argv[2] || null;
+// Defaults to the dev account rather than whichever cube owner the mirror happens to list first —
+// the token is for poking at the Activity as yourself.
+const DEV_DISCORD_ID = '256236315144749059';
+const WANTED = process.argv[2] || DEV_DISCORD_ID;
 const SECRET = process.env.CUBE_JWT_SECRET;
 
 if (!SECRET) {
@@ -40,9 +43,7 @@ const tick = function () {
     const keys = Object.keys(users);
 
     if (keys.length) {
-        const key = WANTED
-            ? keys.find(k => String(users[k]?.discordID) === String(WANTED))
-            : keys.find(k => users[k]?.random?.effects?.chance_cube);
+        const key = keys.find(k => String(users[k]?.discordID) === String(WANTED));
 
         if (key) {
             const p = users[key].random || {};
@@ -65,12 +66,7 @@ const tick = function () {
             process.stdout.write(`${token}\n`);
             process.exit(0);
         }
-        if (WANTED) {
-            console.error(`No player with discord id ${WANTED}.`);
-            process.exit(1);
-        }
-        console.error(`None of the ${keys.length} players own the chance cube. `
-            + 'Grant it with scripts/grantChanceCube.js first.');
+        console.error(`No player with discord id ${WANTED} among the ${keys.length} in the mirror.`);
         process.exit(1);
     }
 

--- a/scripts/cubeFixtures.js
+++ b/scripts/cubeFixtures.js
@@ -92,6 +92,8 @@ const responseOf = (thrown, settled) => ({
     stake: thrown.run.stake,
     opening: thrown.opening,
     breaker: thrown.breaker,
+    rerolls: thrown.res.rerolls,
+    shortcut: thrown.res.shortcut,
     ended: thrown.res.ended,
     ...(settled ? { settled } : {}),
 });
@@ -107,11 +109,24 @@ const WANTED = {
     ratts: r => r.settled?.reason === 'ratts',
     shattered: r => r.settled?.shattered?.length >= 1,
     tieBroken: r => !!r.breaker,
+    // A tie he breaks that also has something waiting on the answer: a Multiplier naming a side, or a
+    // Shortcut. Those labels are held back until his cube lands, so this is the only shape that exercises
+    // the second half of the count — with plain `tieBroken` there is nothing to hold and the walk looks
+    // no different from any other.
+    tieBrokenHeld: r => !!r.breaker && ((r.pays || []).some(p => p.note?.side) || r.shortcut),
     tieAsking: r => !r.settled,
     longLine: r => r.line.length >= 14,
     pure: r => r.settled?.pure,
     cackle: r => r.settled?.reason === 'cackle',
     banked: r => r.settled?.outcome === 'bank',
+    // A banked reroll with its face still on the line, so the walk's `+1 reroll` has a cube to come
+    // off. Nothing in the set had one, which meant the one readout with two sources was the one
+    // nothing could animate.
+    reroll: r => r.rerolls > 0 && r.line.includes('reroll'),
+    // A reroll banked by a face the line no longer shows — written over in the second pass, or paid by
+    // a copy that was never thrown. The stock moves with no cube under it, which is the only shape
+    // that exercises counting it off the middle of the row instead.
+    orphanReroll: r => r.rerolls > r.line.filter(id => id === 'reroll').length,
 };
 
 const sweep = async function (found, opts, budget) {
@@ -156,8 +171,11 @@ const sweep = async function (found, opts, budget) {
     // Most shapes come out of a fully-equipped player who owns everything.
     let attempts = await sweep(found, {}, 300000);
     // Except a tie Watto actually *breaks*: owning Bribe means he asks instead of rolling, so the
-    // only way to see his cube land is a player who cannot buy the tie off him.
-    if (!found.tieBroken) attempts += await sweep(found, { bribe: false }, 100000);
+    // only way to see his cube land is a player who cannot buy the tie off him. Both breaker shapes come
+    // from that pass, so it runs while either is still missing rather than only for the first.
+    if (!found.tieBroken || !found.tieBrokenHeld) {
+        attempts += await sweep(found, { bribe: false }, 300000);
+    }
 
     const missing = Object.keys(WANTED).filter(k => !found[k]);
     fs.mkdirSync(path.dirname(OUT), { recursive: true });

--- a/src/api/cube.js
+++ b/src/api/cube.js
@@ -176,6 +176,13 @@ module.exports = function mountCube(app, ctx) {
         stake: thrown.run.stake,
         opening: thrown.opening,
         breaker: thrown.breaker,
+        // What the roll banked, as totals rather than as faces — and the client cannot derive either
+        // from `line`. Both pay in the first pass and can be written over in the second, which leaves
+        // the line with no position to count them off; a mirrored copy pays without ever having been
+        // thrown. Sent for the same reason a razed greed still gets a `pays` entry with no `at`: a
+        // readout that climbs with nothing on screen to explain it reads as a bug.
+        rerolls: thrown.res.rerolls,
+        shortcut: thrown.res.shortcut,
         ended: thrown.res.ended,
         ...(settled ? { settled } : {}),
     });

--- a/src/game/cube/actions.js
+++ b/src/game/cube/actions.js
@@ -169,7 +169,7 @@ const settleThrow = async function (ctx, { thrown, bribed = 0, reverse = 0 }) {
 
     const outcome = won
         ? await settleWin(ctx, { run, level, majority, pure, cubes, standing, mult, patch, records, res, stillSpent, breaker, bribed, bag })
-        : settleLoss(ctx, { run, res, patch });
+        : settleLoss(ctx, { run, res, thrown, patch });
 
     persist.writeCube(profileRef, profile, patch);
 
@@ -187,11 +187,10 @@ const settleThrow = async function (ctx, { thrown, bribed = 0, reverse = 0 }) {
 exports.settleThrow = settleThrow;
 
 // A bust. A quarter of the stake feeds the pot and the rest leaves the economy.
-const settleLoss = function (ctx, { run, res, patch }) {
+const settleLoss = function (ctx, { run, res, thrown, patch }) {
     const { s, db, database, discordId } = ctx;
     persist.addToPot(database, db, persist.potCut(run.stake));
     pstate.recordLost(s, patch, run.stake);
-    persist.clearLadder(database, db, discordId);
     // Four ways to lose, reported as which one rather than as a sentence. A line with no majority
     // only reaches here once the tie-breaker has already gone the house's way; Ratts is checked
     // first because he ends the run whatever the cubes said.
@@ -199,6 +198,37 @@ const settleLoss = function (ctx, { run, res, patch }) {
         : !res.majority ? 'tie'
             : res.swept ? 'cackle'
                 : 'bust';
+
+    // A bust with a reroll banked stays on file, because that is what `spendReroll` replays. Kept in
+    // the live run's own node and marked `dead`, which `ladderOf` refuses — so this *replaces* the
+    // clear rather than following it, one write to one key instead of a `remove()` and a `set()`
+    // racing on the same ref.
+    //
+    // `mult` is the multiple the run carried *into* the level, not the one this roll played for:
+    // `throwLevel` steps it again on the way back. The cubes are stored as they were **thrown**, since
+    // a reroll picks that table up again — `res.set` is post-effects and would shrink it.
+    //
+    // The embed writes its own richer node over this one, which is where `flavor` and `lines` come
+    // from; `deadFrame` reads both as optional.
+    if (s.rerolls > 0) {
+        persist.saveLadder(database, db, discordId, {
+            stake: run.stake,
+            standing: run.standing || 0,
+            level: run.level,
+            call: run.call,
+            mult: Number(run.mult) || 0,
+            spent: run.spent || [],
+            set: engine.encodeSet(thrown.set),
+            bag: engine.encodeSet(thrown.bag),
+            faces: res.faceIds,
+            roll: res.cubes,
+            reason,
+            dead: true,
+        });
+    } else {
+        persist.clearLadder(database, db, discordId);
+    }
+
     return {
         outcome: 'bust',
         reason,

--- a/src/game/cube/tuning.js
+++ b/src/game/cube/tuning.js
@@ -173,10 +173,14 @@ exports.SPECIALS = [
         // how often it pays. It used to shatter *itself* on every payout, which capped it at one
         // reroll a run — but it also meant the cube reported a shatter every single time it did its
         // job and never once showed the face that actually breaks it. So the brake is a **wipeout**
-        // instead: one face in six takes the cube off the table, like Shmi, Anakin and the
-        // Multiplier, and it renders as the wipeout because that is what it is.
+        // instead: two faces in six take the cube off the table, as on the Multiplier — Shmi and
+        // Anakin carry one apiece — and it renders as the wipeout because that is what it is.
+        //
+        // The face list below is the third distribution this cube has had and the blurb had been left
+        // describing the first. Read it off `faces`, not off the prose around it: three faces bank,
+        // two shatter, one is Ratts.
         id: 'reroll', name: 'Reroll Cube',
-        blurb: 'Four faces bank a reroll. One shatters the cube, one ends the run.',
+        blurb: 'Three faces bank a reroll. Two shatter the cube, one ends the run.',
         faces: [...rep(3, { kind: 'reroll', id: 'reroll' }), END, ...rep(2, BROKEN)],
     },
     {


### PR DESCRIPTION
Server side of the Activity board work on `junkyard@chance-cube-activity`, which is already deployed. Until this merges and ships, the board's reroll stock and shortcut readouts show whatever `/state` last said rather than what the roll banked, and "Spend a reroll" has nothing to put back on the table.

## What's in it

**A bust with a reroll banked stays on file.** `settleLoss` cleared the ladder unconditionally, so `spendReroll` had nothing to replay. It now writes the run back into the same key marked `dead` — one write to one key rather than a `remove()` and a `set()` racing on the same ref — and `ladderOf` refuses it as live. With no reroll banked, nothing is kept, exactly as before.

**The roll response carries `rerolls` and `shortcut`.** Neither is derivable from `line`: both pay in the first pass and can be written over in the second, and a mirrored copy pays without ever having been thrown. A client counting the faces it can still see undercounts while the readout moves anyway.

**The Reroll Cube's blurb now matches its faces.** The list had been changed twice and the prose still described the first distribution — it promised four banking faces and one shatter against a cube that ships three, one Ratts and two wipeouts. The doc's variant table predates the brake and is flagged as unmeasured rather than left reading as current.

**The dev token defaults to the dev account** instead of whichever cube owner the mirror lists first.

## Testing

`node scripts/cubeApiSmoke.js` — 50/50, including six new checks: the two totals are typed even at zero (to a client reading `|| 0`, a missing field and "banked none" are the same answer), a bust with no reroll leaves no node at all (checked against the mirror, since a dead node also reads as no live run from the board), and a seeded dead run replays the stored table at the same level, spending the stock.

Fixtures regenerated with the shapes the board's count walk needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)