### PR TITLE
Tourney hardening: fix cron setup card, guard pre-race event rendering

### DIFF
--- a/src/cron/jobs/liveMatchSetup.js
+++ b/src/cron/jobs/liveMatchSetup.js
@@ -130,7 +130,9 @@ scheduler.register({
                         content: `<@&${LIVEMATCH_ROLE_ID}> **${matchLabel(fresh)}** — match starts ${startTag(startMs)}`,
                         allowedMentions: { roles: [LIVEMATCH_ROLE_ID] },
                     });
-                    await channel.send({ flags: MessageFlags.IsComponentsV2, components: [view] });
+                    // setupMatchView already returns [container] — wrapping it again
+                    // nests the array and Discord rejects the payload (no setup card).
+                    await channel.send({ flags: MessageFlags.IsComponentsV2, components: view });
                 } catch (err) {
                     console.error(`[cron:liveMatchSetup] setup post failed for ${match.id}`, err?.message ?? err);
                 }

--- a/src/interactions/tourney.js
+++ b/src/interactions/tourney.js
@@ -3,7 +3,11 @@ module.exports = {
     name: 'tourney',
     async execute({ client, interaction, args, database, db, member_id, member_name, member_avatar, user_key, user_profile, userSnapshot } = {}) {
         if (args[0] == "play") {
-            play({ client, interaction, args, database, db, member_id, member_name, member_avatar, user_key, user_profile, userSnapshot })
+            // Must be awaited: without it a throw inside play() becomes an
+            // unhandledRejection instead of reaching the caller's try/catch,
+            // and the player sees a dead button (the interaction was already
+            // deferred, so no error ever renders).
+            await play({ client, interaction, args, database, db, member_id, member_name, member_avatar, user_key, user_profile, userSnapshot })
         }
     }
 }

--- a/src/interactions/tourney/functions.js
+++ b/src/interactions/tourney/functions.js
@@ -711,10 +711,14 @@ exports.getPoolOption = function (option, selected) {
 }
 
 exports.getEventOption = function (option, selected) {
+    // Authored option content is free text from the ruleset editor; Discord
+    // hard-rejects the whole select menu when label/description/value exceed
+    // 100 chars, and an option without an `events` array must not throw here.
+    const bundled = Array.isArray(option.events) ? option.events : []
     const eventOption = {
-        label: option.name || option.id,
-        description: `${option.description || ""} (${option.events.length}${option.events.some(event => event.type == 'dynamicEvent') ? "+" : ""} events)`,
-        value: option.id,
+        label: String(option.name || option.id).substring(0, 100),
+        description: `${option.description || ""} (${bundled.length}${bundled.some(event => event.type == 'dynamicEvent') ? "+" : ""} events)`.substring(0, 100),
+        value: String(option.id).substring(0, 100),
         default: selected
     }
 
@@ -738,7 +742,11 @@ exports.optionGetters = {
 
 exports.eventSelector = function ({ event, options, index } = {}) {
     const eventRow = new ActionRowBuilder()
-    const eventOptions = options?.[event.id]
+    // Prefer the API's enriched per-event options (ban/repeat status), but fall
+    // back to the event's own authored options — a render path that never called
+    // the API (e.g. a stale component interaction) has no options map, and a
+    // bare `.forEach` on undefined would kill the whole pre-race view.
+    const eventOptions = options?.[event.id] ?? event.options ?? []
     let eventQty = (event.qty == 1 ? event.type : `${event.qty} ${event.type}s`)
     let placeholder = event.name || capitalize(
         [
@@ -797,19 +805,21 @@ exports.eventSelector = function ({ event, options, index } = {}) {
         return eventRow
     }
 
-    eventOptions.forEach(option => {
+    // Route through the zero-option guard: Discord rejects a select menu with no
+    // options (BASE_TYPE_BAD_LENGTH), which would fail the entire V2 view.
+    const builtOptions = eventOptions.map(option => {
         const selected = event.selection?.some(selection => selection.id == option.id)
         const getOption = exports.optionGetters[event.type]
-        event_selector.addOptions(
-            getOption
-                ? getOption(option, selected)
-                : { label: option.id, value: option.id, default: selected }
-        )
+        return getOption
+            ? getOption(option, selected)
+            : { label: String(option.id), value: String(option.id), default: selected }
     })
+    attachSelectOptions(event_selector, builtOptions)
 
     //overwrite description with ban / repeat status
     event_selector.options.forEach(option => {
         const matchingOption = eventOptions.find(o => o.id == option.data.value)
+        if (!matchingOption) return // e.g. the disabled '__none__' placeholder
         if (matchingOption.banStatus) {
             option.data.description = banStatusMap[matchingOption.banStatus].name
             option.data.emoji = { name: banStatusMap[matchingOption.banStatus].emoji }


### PR DESCRIPTION
## Summary
- **Fix the live-match setup card never posting from cron**: `setupMatchView` already returns `[container]`; wrapping it again nested the components array, Discord rejected the payload, and the catch swallowed the error — so the role ping went out but no setup card ever appeared. Broken since the cron was introduced. Now matches every other send site.
- **`await play()`** in the tourney interaction: without it, any throw inside `play` became an unhandledRejection instead of reaching the handler's try/catch, and the player saw a dead button.
- **`getEventOption` guards**: tolerate authored options without an `events` array, and truncate label/description/value to Discord's 100-char component limits (a long ruleset-authored option description previously killed the entire pre-race view).
- **`eventSelector` resilience**: fall back to the event's own authored options when the API options map is absent, route options through the zero-option guard (disabled placeholder instead of a rejected message), and skip the ban/repeat overwrite for the placeholder row.

## Testing
- Rendered the Bo9 first-track poll through discord.js eager component validation for each failure path: missing options map, missing `events` array, 101-char description, zero options — all render instead of throwing.
- Verified the double-wrapped cron payload serializes to a nested array Discord rejects, while the fixed shape serializes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)