### PR TITLE
Let the SSE stream bypass the buffering CDN via BOTTO_SSE_BASE_URL

### DIFF
--- a/src/sseClient.js
+++ b/src/sseClient.js
@@ -40,10 +40,15 @@ function dispatch(event) {
 }
 
 function connect() {
-    const base = process.env.BOTTO_API_BASE_URL
+    // SSE needs a host that actually streams. The main API base may sit behind
+    // Firebase Hosting's rewrite, which buffers responses — events then arrive
+    // in late bursts on reconnect replay instead of in real time. Point
+    // BOTTO_SSE_BASE_URL at the direct Cloud Run mapping
+    // (e.g. https://events.bottosjunkyard.com/api/v1/) to bypass the CDN.
+    const base = process.env.BOTTO_SSE_BASE_URL || process.env.BOTTO_API_BASE_URL
     const token = process.env.BOT_API_KEY
     if (!base || !token) {
-        console.warn('[sseClient] BOTTO_API_BASE_URL or BOT_API_KEY missing, not connecting')
+        console.warn('[sseClient] BOTTO_SSE_BASE_URL/BOTTO_API_BASE_URL or BOT_API_KEY missing, not connecting')
         return
     }
 
@@ -55,7 +60,7 @@ function connect() {
 
     source.addEventListener('open', () => {
         backoffMs = INITIAL_BACKOFF_MS
-        console.log('[sseClient] connected')
+        console.log(`[sseClient] connected to ${url}`)
     })
 
     source.addEventListener('entity', (msg) => {


### PR DESCRIPTION
## Summary
The bot's SSE connection reuses `BOTTO_API_BASE_URL`. When that points at the Firebase Hosting rewrite (`bottosjunkyard.com/api`), the stream is buffered by the CDN — live announcements (`match.resolveSystemEvent`, e.g. the *Random* first-track reveal, and `match.revealDeferredEvents`) only arrive in a late burst when the connection cycles and Last-Event-ID replay catches up.

This adds `BOTTO_SSE_BASE_URL` — when set, the SSE stream connects there instead (the direct Cloud Run mapping, `https://events.bottosjunkyard.com/api/v1/`, which is exactly why that domain exists — the website's SSE already uses it). Falls back to `BOTTO_API_BASE_URL` unchanged, so the change is inert until the config var is set. The connect log now includes the URL for easy verification.

## Endpoint probe (with the real bot token)
| Endpoint | Result |
|---|---|
| `bottosjunkyard.com/api/v1/events` (Hosting rewrite) | 0 bytes in 6 s — fully buffered, no initial SSE nudge |
| direct Cloud Run URL | heartbeats streamed immediately |
| App Hosting `hosted.app` URL | 401 — proxy strips `x-bot-token`, unusable for the stream |

## Deploy note
After merging, set the config var and deploy:
```
heroku config:set BOTTO_SSE_BASE_URL=https://events.bottosjunkyard.com/api/v1/ --app swe1rbotto
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)